### PR TITLE
Create CMS template.

### DIFF
--- a/pypi/__init__.py
+++ b/pypi/__init__.py
@@ -41,6 +41,8 @@ def init_routing(config):
     config.add_route('register', '/account/register')
     config.add_route('logout', '/account/logout')
 
+    # cms controller -- ADD AT VERY END (it'll match any URL)
+    config.add_route('cms_page', '*subpath')
 
 
     config.scan()

--- a/pypi/controllers/cms_controller.py
+++ b/pypi/controllers/cms_controller.py
@@ -1,0 +1,29 @@
+from pyramid.view import view_config
+from pyramid.request import Request
+from pyramid.httpexceptions import HTTPNotFound
+
+
+fake_db = {
+    'company/history': {
+        'page_title': 'Company history',
+        'page_details': 'Details about company history...',
+    },
+    'company/employees': {
+        'page_title': 'Our team',
+        'page_details': 'Details about company employees ...',
+    },
+}
+
+
+@view_config(route_name='cms_page',
+             renderer='pypi:templates/cms/page.pt')
+def cms_page(request: Request):
+    subpath = request.matchdict.get('subpath')
+    suburl = '/'.join(subpath)  # join iterable subpath to string
+
+    page = fake_db.get(suburl)
+    if not page:
+        raise HTTPNotFound()
+
+    return page
+

--- a/pypi/templates/cms/page.pt
+++ b/pypi/templates/cms/page.pt
@@ -1,0 +1,16 @@
+<div metal:use-macro="load: ../shared/_layout.pt">
+    <div metal:fill-slot="content">
+
+        <div class="content">
+            <h1>${page_title}</h1>
+            <div>
+                ${structure:page_details}
+            </div>
+        </div>
+
+    </div>
+
+    <div metal:fill-slot="additional-css" tal:omit-tag>
+        <!--additional css from the page-->
+    </div>
+</div>


### PR DESCRIPTION
This PR adds a controller and template that can be used to generate pages from an arbitrary url, by adding a page title and details as a database entry associated with the url. This provides the capability to add static pages, in the same way you'd build a website with a content management system like wordpress.